### PR TITLE
Fix bug with one-word projects

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -29,7 +29,7 @@ jobs:
         flake8 . --count --max-complexity=10 --max-line-length=100 --statistics
     - name: Test with pytest (quick)
       run: |
-        pytest -v -x -n auto
+        python -m pytest -v -x -n auto
     - name: Test with pytest
       run: |
         python -m coverage run -m pytest -v


### PR DESCRIPTION
## Issues fixed

* Fix the bug that occurs when this template is used to create a new repository whose name is one word with no hyphens (closes #24)