### PR TITLE
Remove Python requirement from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,3 @@ version = 1.1.0
 
 [options]
 packages = find:
-python_requires = >=3.10
-install_requires =
-    requests
-    importlib; python_version == "3.10"


### PR DESCRIPTION
### Improvements

- Remove Python version requirement from `setup.cfg`
