### PR TITLE
Resolve pylint import error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         flake8 . --count --max-complexity=10 --max-line-length=100 --statistics
     - name: Lint with pylint
       run: |
-        python -m pylint ../python-project-template
+        python -m pylint games_of_chance/
     - name: Test with pytest (quick)
       run: |
         python -m pytest -v -x -n auto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@
 
 ## [1.1.0](https://github.com/viperior/python-project-template/tree/v1.1.0) (2022-06-27)
 
+### Issues fixed
+
+- Resolve the pylint import error encountered during the GitHub Action workflow execution (closes [#58](https://github.com/viperior/python-project-template/issues/58))
+
 ### Improvements
 
 - Move the tests related to the example module into example/tests (closes [#36](https://github.com/viperior/python-project-template/issues/36))
+- Simplify the import statement in the coin flip test case
 - Ignore `.venv` directory when linting with flake8 (closes [#53](https://github.com/viperior/python-project-template/issues/53))
 - Update the required Python version in `setup.cfg` to 3.10 (closes [#56](https://github.com/viperior/python-project-template/issues/56))
 - Dependency updates

--- a/games_of_chance/tests/test_flip_coins_function.py
+++ b/games_of_chance/tests/test_flip_coins_function.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from games_of_chance.flip_coins import flip_coins
+import games_of_chance.flip_coins
 
 
 @pytest.mark.parametrize("coin_count", list(range(11)) + list(range(10, 200, 10)) + [1, 2] * 30)
@@ -18,7 +18,8 @@ def test_foo_function(coin_count: int) -> None:
     None
     """
     try:
-        coin_flip_result = flip_coins(coins_to_flip=coin_count, chosen_side="heads")
+        coin_flip_result = games_of_chance.flip_coins.flip_coins(coins_to_flip=coin_count,
+                                                                 chosen_side="heads")
         logging.debug("coin_flip_result = %s", coin_flip_result)
 
         assert coin_flip_result["result"] in ["won", "lost", "tie"]


### PR DESCRIPTION
### Issues fixed

- Resolve the pylint import error encountered during the GitHub Action workflow execution (closes [#58](https://github.com/viperior/python-project-template/issues/58))

### Improvements

- Simplify the import statement in the coin flip test case
