### PR TITLE
Resolve pylint import error

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -32,7 +32,7 @@ ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-init-hook='import os, sys; sys.path.append(os.getcwd())'
+init-hook=
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use.


### PR DESCRIPTION
### Issues fixed

- Delete the `__init__.py` file at the project root and remove the path manipulation in the pylint control file (closes #58)
