### PR TITLE
Configure Dependabot to monitor for updates to GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## [1.1.0](https://github.com/viperior/python-project-template/tree/v1.1.0) (2022-06-27)
 
+### New features
+
+- Configure dependabot to update GitHub Actions (closes [#64](https://github.com/viperior/python-project-template/issues/64))
+
 ### Issues fixed
 
 - Resolve the pylint import error encountered during the GitHub Action workflow execution (closes [#58](https://github.com/viperior/python-project-template/issues/58))


### PR DESCRIPTION
### New features

- Configure dependabot to update GitHub Actions (closes [#64](https://github.com/viperior/python-project-template/issues/64))
