### PR TITLE
Exclude FUNDING.yml from template

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: viperior
-ko_fi: jstone


### PR DESCRIPTION
### Improvements

- Exclude the sponsorship config file by default in the template (closes #124)
